### PR TITLE
Updated ita name

### DIFF
--- a/data/144/483/049/3/1444830493.geojson
+++ b/data/144/483/049/3/1444830493.geojson
@@ -29,7 +29,7 @@
     "name:ita_x_preferred":[
         "Cadidavid"
     ],
-    "name:iva_x_variant":[
+    "name:ita_x_variant":[
         "Ca' di David"
     ],
     "src:geom":"whosonfirst",
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":1444830493,
-    "wof:lastmodified":1566721993,
+    "wof:lastmodified":1568232957,
     "wof:name":"Cadidavid",
     "wof:parent_id":101752711,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes the a portion of whosonfirst-data/whosonfirst-data#1709

This PR removes any bunk iso codes/name properties and empty name lists. Unfortunately, the Git history does not reveal where these empty name strings come from. I also ran this record against wikidata to gain new names, but no new names were found.

This does not require PIP work. Can be merged once approved.